### PR TITLE
fix: use impit for HTTP requests to bypass Cloudflare TLS fingerprinting

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
 		"bullmq": "5.67.3",
 		"cheerio": "1.2.0",
 		"consola": "3.4.2",
+		"impit": "^0.9.2",
 		"ioredis": "5.9.2",
 		"isomorphic-dompurify": "2.36.0",
 		"marked": "17.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       consola:
         specifier: 3.4.2
         version: 3.4.2
+      impit:
+        specifier: ^0.9.2
+        version: 0.9.2
       ioredis:
         specifier: 5.9.2
         version: 5.9.2
@@ -5531,6 +5534,58 @@ packages:
 
   image-meta@0.2.2:
     resolution: {integrity: sha512-3MOLanc3sb3LNGWQl1RlQlNWURE5g32aUphrDyFeCsxBTk08iE3VNe4CwsUZ0Qs1X+EfX0+r29Sxdpza4B+yRA==}
+
+  impit-darwin-arm64@0.9.2:
+    resolution: {integrity: sha512-YHfrBeWwwI6je3OLBK8kgxR49bLbYGLkF/HFUHjPnhZxR821zd0NNPsYMX/1Rrasx0Zpu3skhN68ofudilhHdg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  impit-darwin-x64@0.9.2:
+    resolution: {integrity: sha512-FPH7gE0YdHfYRjX9qGKIvfQ6hdgo9GM+/wD1ktUC2UiEwKbwjpmrBhdXt0bSudrw9D28T4KR1w4TmX4X+uBYEA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  impit-linux-arm64-gnu@0.9.2:
+    resolution: {integrity: sha512-9Va4WmklAWwjJYT5M74u6HHzmRA8Tw8tdwzsrhIBmEyJ/gzCD6TJD0sE0mgFGd8v/mEB/WfMX1VnpOQmPm1gDQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  impit-linux-arm64-musl@0.9.2:
+    resolution: {integrity: sha512-eiZs4C4vOPRi5A/V/bNTpX9Ays1m1trMfDXRH/Bnulo7XPngP6AEGW0SaKBznfDhiFOfO7hcDPupkGvSfX5rpw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  impit-linux-x64-gnu@0.9.2:
+    resolution: {integrity: sha512-KXkc6A0jh6c1ymxbcxgMbjNwr7YCm48froJaQWzXHg9nRSepJxprHtlWoFcz9HG/D9+eBQXTpMAJMAqXMs+NtA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  impit-linux-x64-musl@0.9.2:
+    resolution: {integrity: sha512-GWXqohv79LgOF0YUP/rwVGZ4uQZWK/NJUhGZR4PgKRMb1HHH2S2wrGtSP7AHyW+GT27Tv9yrRcyidVK+FYxOVw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  impit-win32-arm64-msvc@0.9.2:
+    resolution: {integrity: sha512-ta82EKAMjCXhnCs6n9jr7hzbjX3wBWhW21AdAwZEiX4RaJNmE6j0oH0ZrTZuCDJumxAV+1pJapB4q/BCuoP1IQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  impit-win32-x64-msvc@0.9.2:
+    resolution: {integrity: sha512-S1F8b4sKYwd0FORJWir4rrU0iZbQwebY+U/lkSJOK316P46sH8wu8wHB4TLVLLNpAUI0bp4sBgXlholqtlDAQw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  impit@0.9.2:
+    resolution: {integrity: sha512-flHQYxC16o7H+OKrO0zXv8Ob8Hs/E1Z1CfjGUHkN+6qqQksi1/2KMnZZEeSWfB9fM4b8SQVL6aQha/K6qVKqng==}
+    engines: {node: '>= 20'}
 
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
@@ -14583,6 +14638,41 @@ snapshots:
   ignore@7.0.5: {}
 
   image-meta@0.2.2: {}
+
+  impit-darwin-arm64@0.9.2:
+    optional: true
+
+  impit-darwin-x64@0.9.2:
+    optional: true
+
+  impit-linux-arm64-gnu@0.9.2:
+    optional: true
+
+  impit-linux-arm64-musl@0.9.2:
+    optional: true
+
+  impit-linux-x64-gnu@0.9.2:
+    optional: true
+
+  impit-linux-x64-musl@0.9.2:
+    optional: true
+
+  impit-win32-arm64-msvc@0.9.2:
+    optional: true
+
+  impit-win32-x64-msvc@0.9.2:
+    optional: true
+
+  impit@0.9.2:
+    optionalDependencies:
+      impit-darwin-arm64: 0.9.2
+      impit-darwin-x64: 0.9.2
+      impit-linux-arm64-gnu: 0.9.2
+      impit-linux-arm64-musl: 0.9.2
+      impit-linux-x64-gnu: 0.9.2
+      impit-linux-x64-musl: 0.9.2
+      impit-win32-arm64-msvc: 0.9.2
+      impit-win32-x64-msvc: 0.9.2
 
   import-fresh@3.3.1:
     dependencies:

--- a/server/lib/scrapers/japscan/index.ts
+++ b/server/lib/scrapers/japscan/index.ts
@@ -73,10 +73,6 @@ export class Japscan implements SourceProvider {
 
 		this.#apiInformation = {
 			api_url: new URL(BASE_URL),
-			headers: new Map([
-				["User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:71.0) Gecko/20100101 Firefox/77.0"],
-				["Referer", `${BASE_URL}/`],
-			]),
 			canBlockScraping: true,
 			minimumUpdateInterval: 300 * 60,
 			timeout: 60,

--- a/server/lib/scrapers/mangadex/index.ts
+++ b/server/lib/scrapers/mangadex/index.ts
@@ -1,5 +1,6 @@
 import { setTimeout } from "node:timers/promises"
 
+import type { Impit } from "impit"
 import {
 	ChapterNotFoundError,
 	type FetchSearchSerieFilter,
@@ -54,7 +55,9 @@ export class Mangadex implements SourceProvider {
 
 	#apiInformation: SourceApiInformation
 
-	constructor(env: SourceEnv) {
+	#impit: Impit
+
+	constructor(env: SourceEnv, impit: Impit) {
 		const enabledLanguages = env.ENABLED_LANGUAGE.filter(enabled_lang =>
 			MANGADEX_LANGUAGE.some(lang => enabled_lang === lang),
 		)
@@ -102,6 +105,8 @@ export class Mangadex implements SourceProvider {
 			rateLimitMax: 5,
 			rateLimitDuration: 60_000, // 5 requests per minute
 		}
+
+		this.#impit = impit
 	}
 
 	sourceApiInformation(): SourceApiInformation {
@@ -197,7 +202,7 @@ export class Mangadex implements SourceProvider {
 
 		const url = new URL(`manga?${params}`, this.#apiInformation.api_url)
 
-		const data = await fetch(url, { method: "GET" })
+		const data = await this.#impit.fetch(url)
 
 		if (!data.ok) {
 			throw new Error(`MangaDex API HTTP error: ${data.status} ${data.statusText}`)
@@ -246,7 +251,7 @@ export class Mangadex implements SourceProvider {
 		}
 
 		const chapterUrl = new URL(`chapter?${chapterParams}`, this.#apiInformation.api_url)
-		const chapterData = await fetch(chapterUrl, { method: "GET" })
+		const chapterData = await this.#impit.fetch(chapterUrl)
 
 		if (!chapterData.ok) {
 			throw new Error(`MangaDex API HTTP error: ${chapterData.status} ${chapterData.statusText}`)
@@ -285,7 +290,7 @@ export class Mangadex implements SourceProvider {
 		}
 
 		const mangaUrl = new URL(`manga?${mangaParams}`, this.#apiInformation.api_url)
-		const mangaData = await fetch(mangaUrl, { method: "GET" })
+		const mangaData = await this.#impit.fetch(mangaUrl)
 
 		if (!mangaData.ok) {
 			throw new Error(`MangaDex API HTTP error: ${mangaData.status} ${mangaData.statusText}`)
@@ -321,7 +326,7 @@ export class Mangadex implements SourceProvider {
 
 		const url = new URL(`manga/${serie_id}?${params}`, this.#apiInformation.api_url)
 
-		const data = await fetch(url, { method: "GET" })
+		const data = await this.#impit.fetch(url)
 
 		if (!data.ok) {
 			throw new Error(`MangaDex API HTTP error: ${data.status} ${data.statusText}`)
@@ -366,7 +371,7 @@ export class Mangadex implements SourceProvider {
 			params.set("offset", offset.toString())
 			const url = new URL(`manga/${serieId}/feed?${params}`, this.#apiInformation.api_url)
 
-			const data = await fetch(url, { method: "GET" })
+			const data = await this.#impit.fetch(url)
 
 			if (!data.ok) {
 				throw new Error(`MangaDex API HTTP error: ${data.status} ${data.statusText}`)
@@ -402,7 +407,7 @@ export class Mangadex implements SourceProvider {
 
 		const url = new URL(`at-home/server/${chapterId}?${params}`, this.#apiInformation.api_url)
 
-		const data = await fetch(url, { method: "GET" })
+		const data = await this.#impit.fetch(url)
 
 		if (!data.ok) {
 			if (data.status === 404) {

--- a/server/lib/scrapers/mangadex/index.ts
+++ b/server/lib/scrapers/mangadex/index.ts
@@ -96,9 +96,6 @@ export class Mangadex implements SourceProvider {
 
 		this.#apiInformation = {
 			api_url: new URL("https://api.mangadex.org"),
-			headers: new Map([
-				["User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:71.0) Gecko/20100101 Firefox/77.0"],
-			]),
 			canBlockScraping: true,
 			minimumUpdateInterval: 300 * 60,
 			timeout: 30,

--- a/server/lib/scrapers/suwayomi/index.ts
+++ b/server/lib/scrapers/suwayomi/index.ts
@@ -65,7 +65,6 @@ export class SuwayomiSource implements SourceProvider {
 
 		this.#apiInformation = {
 			api_url: new URL(client.baseUrl),
-			headers: new Map(),
 			minimumUpdateInterval: 3600,
 			timeout: 30,
 			canBlockScraping: false,

--- a/server/lib/scrapers/weebcentral/index.ts
+++ b/server/lib/scrapers/weebcentral/index.ts
@@ -1,4 +1,5 @@
 import { load } from "cheerio"
+import type { Impit } from "impit"
 import { assignSeasonedChapterNumbers, calculateMissingChapters } from "~~/shared/utils/chapters"
 import {
 	ChapterNotFoundError,
@@ -42,7 +43,9 @@ export class WeebCentral implements SourceProvider {
 
 	#apiInformation: SourceApiInformation
 
-	constructor(env: SourceEnv) {
+	#impit: Impit
+
+	constructor(env: SourceEnv, impit: Impit) {
 		const enabledLanguages = env.ENABLED_LANGUAGE.filter(enabled_lang =>
 			[SourceLanguage.En].some(lang => enabled_lang === lang),
 		)
@@ -82,7 +85,7 @@ export class WeebCentral implements SourceProvider {
 		this.#apiInformation = {
 			api_url: new URL("https://weebcentral.com"),
 			headers: new Map([
-				["User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:71.0) Gecko/20100101 Firefox/77.0"],
+				["User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:134.0) Gecko/20100101 Firefox/134.0"],
 			]),
 			canBlockScraping: true,
 			minimumUpdateInterval: 300 * 60,
@@ -90,6 +93,8 @@ export class WeebCentral implements SourceProvider {
 			rateLimitMax: 1,
 			rateLimitDuration: 10_000, // 1 request per 10 seconds (HTML scraping)
 		}
+
+		this.#impit = impit
 	}
 
 	sourceApiInformation(): SourceApiInformation {
@@ -194,7 +199,7 @@ export class WeebCentral implements SourceProvider {
 		}
 
 		const url = new URL(`/search/data?${params}`, this.#apiInformation.api_url)
-		const data = await fetch(url, { method: "GET" })
+		const data = await this.#impit.fetch(url)
 
 		if (!data.ok) {
 			throw new Error(`WeebCentral HTTP error: ${data.status} ${data.statusText}`)
@@ -273,7 +278,7 @@ export class WeebCentral implements SourceProvider {
 	async fetchSerieDetail(serieId: SourceSerieId): Promise<SourceSerie> {
 		const url = this.serieUrl(serieId)
 
-		const data = await fetch(url, { method: "GET" })
+		const data = await this.#impit.fetch(url)
 
 		if (!data.ok) {
 			throw new Error(`WeebCentral HTTP error: ${data.status} ${data.statusText}`)
@@ -376,7 +381,7 @@ export class WeebCentral implements SourceProvider {
 		const url = new URL(`series/${serieId}/chapter-select`, this.#information.url)
 		url.searchParams.append("current_chapter", latestKnownChapterId)
 
-		const data = await fetch(url, { method: "GET" })
+		const data = await this.#impit.fetch(url)
 		if (!data.ok) return []
 
 		const html = await data.text()
@@ -407,7 +412,7 @@ export class WeebCentral implements SourceProvider {
 	async fetchSerieChapters(serieId: SourceSerieId): Promise<SourceChapters> {
 		const url = new URL(`series/${serieId}/full-chapter-list`, this.#information.url)
 
-		const data = await fetch(url, { method: "GET" })
+		const data = await this.#impit.fetch(url)
 
 		if (!data.ok) {
 			throw new Error(`WeebCentral HTTP error: ${data.status} ${data.statusText}`)
@@ -519,7 +524,7 @@ export class WeebCentral implements SourceProvider {
 		url.searchParams.append("is_prev", "False")
 		url.searchParams.append("reading_style", "long_strip")
 
-		const data = await fetch(url, { method: "GET" })
+		const data = await this.#impit.fetch(url)
 
 		if (!data.ok) {
 			if (data.status === 404) {

--- a/server/lib/scrapers/weebcentral/index.ts
+++ b/server/lib/scrapers/weebcentral/index.ts
@@ -84,9 +84,6 @@ export class WeebCentral implements SourceProvider {
 
 		this.#apiInformation = {
 			api_url: new URL("https://weebcentral.com"),
-			headers: new Map([
-				["User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:134.0) Gecko/20100101 Firefox/134.0"],
-			]),
 			canBlockScraping: true,
 			minimumUpdateInterval: 300 * 60,
 			timeout: 30,

--- a/server/utils/sources/core.ts
+++ b/server/utils/sources/core.ts
@@ -266,7 +266,6 @@ export type SourceInformation = {
 
 export type SourceApiInformation = {
 	api_url: URL
-	headers: Map<string, string>
 	minimumUpdateInterval: number
 	timeout: number
 	canBlockScraping: boolean

--- a/server/utils/sources/index.ts
+++ b/server/utils/sources/index.ts
@@ -1,4 +1,5 @@
 // Core types and enums
+import { Impit } from "impit"
 import { Japscan } from "../../lib/scrapers/japscan"
 import { Mangadex } from "../../lib/scrapers/mangadex"
 import { createSuwayomiSources } from "../../lib/scrapers/suwayomi/factory"
@@ -30,7 +31,8 @@ export const createSources = async (env: SourceEnvWithSuwayomi): Promise<SourceP
 		return cachedSources
 	}
 
-	const nativeSources: SourceProvider[] = [new WeebCentral(env), new Mangadex(env), new Japscan(env)]
+	const impit = new Impit({ browser: "chrome" })
+	const nativeSources: SourceProvider[] = [new WeebCentral(env, impit), new Mangadex(env, impit), new Japscan(env)]
 
 	// Optionally add Suwayomi sources if configured
 	if (env.SUWAYOMI_URL) {


### PR DESCRIPTION
Cloudflare blocks Node.js native fetch (undici) based on TLS fingerprint. Replace with impit (Chrome TLS fingerprint) in WeebCentral and MangaDex scrapers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced HTTP request handling in scraper modules (Mangadex, WeebCentral) through dependency injection, centralizing and improving control over network requests.

* **Chores**
  * Added new dependency for HTTP request management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->