### PR TITLE
feat: handle 429 rate limits in workers with moveToDelayed

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -87,6 +87,7 @@ export default defineNuxtConfig({
 		experimentalSearchLocalizedAttributes: false,
 		searchMaxTotalHits: 10000,
 		searchMaxValuesPerFacet: 200,
+		rateLimitMaxRetries: 5,
 		byparrUrl: "",
 		apiKeyRateLimitEnabled: "true",
 		apiKeyRateLimitMaxRequests: 10000,

--- a/server/lib/scrapers/mangadex/index.ts
+++ b/server/lib/scrapers/mangadex/index.ts
@@ -2,6 +2,7 @@ import { setTimeout } from "node:timers/promises"
 
 import type { Impit } from "impit"
 import {
+	assertNotRateLimited,
 	ChapterNotFoundError,
 	type FetchSearchSerieFilter,
 	type SourceProvider,
@@ -106,6 +107,12 @@ export class Mangadex implements SourceProvider {
 		this.#impit = impit
 	}
 
+	async #fetch(url: URL) {
+		const response = await this.#impit.fetch(url)
+		assertNotRateLimited(response)
+		return response
+	}
+
 	sourceApiInformation(): SourceApiInformation {
 		return this.#apiInformation
 	}
@@ -199,7 +206,7 @@ export class Mangadex implements SourceProvider {
 
 		const url = new URL(`manga?${params}`, this.#apiInformation.api_url)
 
-		const data = await this.#impit.fetch(url)
+		const data = await this.#fetch(url)
 
 		if (!data.ok) {
 			throw new Error(`MangaDex API HTTP error: ${data.status} ${data.statusText}`)
@@ -248,7 +255,7 @@ export class Mangadex implements SourceProvider {
 		}
 
 		const chapterUrl = new URL(`chapter?${chapterParams}`, this.#apiInformation.api_url)
-		const chapterData = await this.#impit.fetch(chapterUrl)
+		const chapterData = await this.#fetch(chapterUrl)
 
 		if (!chapterData.ok) {
 			throw new Error(`MangaDex API HTTP error: ${chapterData.status} ${chapterData.statusText}`)
@@ -287,7 +294,7 @@ export class Mangadex implements SourceProvider {
 		}
 
 		const mangaUrl = new URL(`manga?${mangaParams}`, this.#apiInformation.api_url)
-		const mangaData = await this.#impit.fetch(mangaUrl)
+		const mangaData = await this.#fetch(mangaUrl)
 
 		if (!mangaData.ok) {
 			throw new Error(`MangaDex API HTTP error: ${mangaData.status} ${mangaData.statusText}`)
@@ -323,7 +330,7 @@ export class Mangadex implements SourceProvider {
 
 		const url = new URL(`manga/${serie_id}?${params}`, this.#apiInformation.api_url)
 
-		const data = await this.#impit.fetch(url)
+		const data = await this.#fetch(url)
 
 		if (!data.ok) {
 			throw new Error(`MangaDex API HTTP error: ${data.status} ${data.statusText}`)
@@ -368,7 +375,7 @@ export class Mangadex implements SourceProvider {
 			params.set("offset", offset.toString())
 			const url = new URL(`manga/${serieId}/feed?${params}`, this.#apiInformation.api_url)
 
-			const data = await this.#impit.fetch(url)
+			const data = await this.#fetch(url)
 
 			if (!data.ok) {
 				throw new Error(`MangaDex API HTTP error: ${data.status} ${data.statusText}`)
@@ -404,7 +411,7 @@ export class Mangadex implements SourceProvider {
 
 		const url = new URL(`at-home/server/${chapterId}?${params}`, this.#apiInformation.api_url)
 
-		const data = await this.#impit.fetch(url)
+		const data = await this.#fetch(url)
 
 		if (!data.ok) {
 			if (data.status === 404) {

--- a/server/lib/scrapers/weebcentral/index.ts
+++ b/server/lib/scrapers/weebcentral/index.ts
@@ -2,6 +2,7 @@ import { load } from "cheerio"
 import type { Impit } from "impit"
 import { assignSeasonedChapterNumbers, calculateMissingChapters } from "~~/shared/utils/chapters"
 import {
+	assertNotRateLimited,
 	ChapterNotFoundError,
 	type FetchSearchSerieFilter,
 	type SourceProvider,
@@ -92,6 +93,12 @@ export class WeebCentral implements SourceProvider {
 		}
 
 		this.#impit = impit
+	}
+
+	async #fetch(url: URL) {
+		const response = await this.#impit.fetch(url)
+		assertNotRateLimited(response)
+		return response
 	}
 
 	sourceApiInformation(): SourceApiInformation {
@@ -196,7 +203,7 @@ export class WeebCentral implements SourceProvider {
 		}
 
 		const url = new URL(`/search/data?${params}`, this.#apiInformation.api_url)
-		const data = await this.#impit.fetch(url)
+		const data = await this.#fetch(url)
 
 		if (!data.ok) {
 			throw new Error(`WeebCentral HTTP error: ${data.status} ${data.statusText}`)
@@ -275,7 +282,7 @@ export class WeebCentral implements SourceProvider {
 	async fetchSerieDetail(serieId: SourceSerieId): Promise<SourceSerie> {
 		const url = this.serieUrl(serieId)
 
-		const data = await this.#impit.fetch(url)
+		const data = await this.#fetch(url)
 
 		if (!data.ok) {
 			throw new Error(`WeebCentral HTTP error: ${data.status} ${data.statusText}`)
@@ -378,7 +385,7 @@ export class WeebCentral implements SourceProvider {
 		const url = new URL(`series/${serieId}/chapter-select`, this.#information.url)
 		url.searchParams.append("current_chapter", latestKnownChapterId)
 
-		const data = await this.#impit.fetch(url)
+		const data = await this.#fetch(url)
 		if (!data.ok) return []
 
 		const html = await data.text()
@@ -409,7 +416,7 @@ export class WeebCentral implements SourceProvider {
 	async fetchSerieChapters(serieId: SourceSerieId): Promise<SourceChapters> {
 		const url = new URL(`series/${serieId}/full-chapter-list`, this.#information.url)
 
-		const data = await this.#impit.fetch(url)
+		const data = await this.#fetch(url)
 
 		if (!data.ok) {
 			throw new Error(`WeebCentral HTTP error: ${data.status} ${data.statusText}`)
@@ -521,7 +528,7 @@ export class WeebCentral implements SourceProvider {
 		url.searchParams.append("is_prev", "False")
 		url.searchParams.append("reading_style", "long_strip")
 
-		const data = await this.#impit.fetch(url)
+		const data = await this.#fetch(url)
 
 		if (!data.ok) {
 			if (data.status === 404) {

--- a/server/queues/chapter-data.ts
+++ b/server/queues/chapter-data.ts
@@ -17,6 +17,7 @@ export const chapterDataJobDataSchema = z.object({
 	source_id: z.string().uuid(),
 	chapter_id: z.string().uuid(),
 	type: z.enum(["UPDATE"]),
+	rate_limit_retry_attempt: z.number().optional(), // Track retry attempts for 429 rate limits
 })
 
 export type ChapterDataJobData = z.infer<typeof chapterDataJobDataSchema>

--- a/server/queues/serie-inserter.ts
+++ b/server/queues/serie-inserter.ts
@@ -19,6 +19,7 @@ export const serieInserterJobDataSchema = z.object({
 	is_primary: z.boolean().optional(), // For linking, whether this should be the primary source
 	expect_new_chapters: z.boolean().optional(), // Set by FETCH_LATEST when serie appeared in latest updates
 	cache_retry_attempt: z.number().optional(), // Track retry attempts for source cache issues
+	rate_limit_retry_attempt: z.number().optional(), // Track retry attempts for 429 rate limits
 })
 
 export type SerieInserterJobData = z.infer<typeof serieInserterJobDataSchema>

--- a/server/utils/sources/byparr.ts
+++ b/server/utils/sources/byparr.ts
@@ -1,3 +1,5 @@
+import { parseRetryAfter, RateLimitError } from "./core"
+
 export type ByparrCookie = {
 	name: string
 	value: string
@@ -77,6 +79,10 @@ export class ByparrClient {
 		if (data.status !== "ok") {
 			throw new Error(`Byparr error: ${data.message}`)
 		}
+		if (data.solution.status === 429) {
+			const retryHeader = data.solution.headers["retry-after"] ?? data.solution.headers["Retry-After"] ?? null
+			throw new RateLimitError(parseRetryAfter(retryHeader))
+		}
 		return data
 	}
 
@@ -107,6 +113,10 @@ export class ByparrClient {
 		const data = (await res.json()) as ByparrResponse
 		if (data.status !== "ok") {
 			throw new Error(`Byparr error: ${data.message}`)
+		}
+		if (data.solution.status === 429) {
+			const retryHeader = data.solution.headers["retry-after"] ?? data.solution.headers["Retry-After"] ?? null
+			throw new RateLimitError(parseRetryAfter(retryHeader))
 		}
 		return data
 	}

--- a/server/utils/sources/byparr.ts
+++ b/server/utils/sources/byparr.ts
@@ -80,7 +80,7 @@ export class ByparrClient {
 			throw new Error(`Byparr error: ${data.message}`)
 		}
 		if (data.solution.status === 429) {
-			const retryHeader = data.solution.headers["retry-after"] ?? data.solution.headers["Retry-After"] ?? null
+			const retryHeader = Object.entries(data.solution.headers).find(([k]) => k.toLowerCase() === "retry-after")?.[1] ?? null
 			throw new RateLimitError(parseRetryAfter(retryHeader))
 		}
 		return data
@@ -115,7 +115,7 @@ export class ByparrClient {
 			throw new Error(`Byparr error: ${data.message}`)
 		}
 		if (data.solution.status === 429) {
-			const retryHeader = data.solution.headers["retry-after"] ?? data.solution.headers["Retry-After"] ?? null
+			const retryHeader = Object.entries(data.solution.headers).find(([k]) => k.toLowerCase() === "retry-after")?.[1] ?? null
 			throw new RateLimitError(parseRetryAfter(retryHeader))
 		}
 		return data

--- a/server/utils/sources/core.ts
+++ b/server/utils/sources/core.ts
@@ -300,3 +300,51 @@ export class ChapterNotFoundError extends Error {
 		this.name = "ChapterNotFoundError"
 	}
 }
+
+export class RateLimitError extends Error {
+	retryAfterMs: number
+
+	constructor(retryAfterMs: number, message?: string) {
+		super(message ?? `Rate limited, retry after ${retryAfterMs}ms`)
+		this.name = "RateLimitError"
+		this.retryAfterMs = retryAfterMs
+	}
+}
+
+/**
+ * Parse a Retry-After header value into milliseconds.
+ * Handles both integer seconds ("120") and HTTP-date formats per RFC 9110.
+ * Clamps between 1s and 1h. Returns defaultMs if header is null/unparseable.
+ */
+export function parseRetryAfter(header: string | null, defaultMs = 60_000): number {
+	if (!header) return defaultMs
+
+	const MIN_MS = 1_000
+	const MAX_MS = 3_600_000
+
+	// Try integer seconds first
+	const seconds = Number(header)
+	if (!Number.isNaN(seconds) && Number.isFinite(seconds)) {
+		return Math.min(Math.max(seconds * 1000, MIN_MS), MAX_MS)
+	}
+
+	// Try HTTP-date
+	const date = new Date(header)
+	if (!Number.isNaN(date.getTime())) {
+		const delayMs = date.getTime() - Date.now()
+		return Math.min(Math.max(delayMs, MIN_MS), MAX_MS)
+	}
+
+	return defaultMs
+}
+
+/**
+ * Throw a RateLimitError if the response has status 429.
+ * Accepts any response-like object (works with both fetch Response and ImpitResponse).
+ */
+export function assertNotRateLimited(response: { status: number, headers: Headers }): void {
+	if (response.status === 429) {
+		const retryAfterMs = parseRetryAfter(response.headers.get("retry-after"))
+		throw new RateLimitError(retryAfterMs)
+	}
+}

--- a/server/workers/chapter-data.ts
+++ b/server/workers/chapter-data.ts
@@ -1,5 +1,5 @@
 import { defineWorker } from "#processor"
-import { MetricsTime, type Job } from "bullmq"
+import { DelayedError, MetricsTime, type Job } from "bullmq"
 import { join } from "node:path"
 import pLimit from "p-limit"
 import type { ChapterDataJobData } from "../queues/chapter-data"
@@ -8,7 +8,7 @@ import type { Chapter, PageFetchStatus, Prisma } from "../utils/db"
 import { db } from "../utils/db"
 import { deleteByPrefix, GifTooLargeError, uploadImageFile } from "../utils/s3"
 import { getSourceById } from "../utils/sources"
-import { ChapterNotFoundError } from "../utils/sources/core"
+import { ChapterNotFoundError, RateLimitError } from "../utils/sources/core"
 
 type PageUploadResult = {
 	success: boolean
@@ -48,6 +48,9 @@ async function processChapterUpdate(
 		images = data.filter((c): c is { type: "image", url: URL, index: number } => c.type === "image")
 	}
 	catch (error) {
+		// Rate limit errors must propagate to the worker for moveToDelayed handling
+		if (error instanceof RateLimitError) throw error
+
 		job.log(`Failed to fetch chapter data: ${error}`)
 
 		// Chapter not found errors are permanent - mark as failed but don't fail the job
@@ -213,7 +216,7 @@ export default defineWorker<typeof QUEUE_NAME, ChapterDataJobData, undefined>({
 		limiter: { max: 2, duration: 5000 },
 		metrics: { maxDataPoints: MetricsTime.ONE_WEEK * 2 },
 	},
-	async processor(job) {
+	async processor(job, token) {
 		const data = chapterDataJobDataSchema.parse(job.data)
 
 		await job.updateProgress(5)
@@ -239,17 +242,39 @@ export default defineWorker<typeof QUEUE_NAME, ChapterDataJobData, undefined>({
 		await job.updateProgress(10)
 
 		if (data.type === "UPDATE") {
-			const status = await processChapterUpdate(job, chapter)
+			try {
+				const status = await processChapterUpdate(job, chapter)
 
-			// Update final status
-			await db.chapter.update({
-				where: { id: chapter.id },
-				data: { page_fetch_status: status },
-			})
+				// Update final status
+				await db.chapter.update({
+					where: { id: chapter.id },
+					data: { page_fetch_status: status },
+				})
 
-			// Throw if completely failed so job is marked as failed
-			if (status === "Failed") {
-				throw new Error("Chapter page fetch failed completely")
+				// Throw if completely failed so job is marked as failed
+				if (status === "Failed") {
+					throw new Error("Chapter page fetch failed completely")
+				}
+			}
+			catch (error) {
+				if (error instanceof RateLimitError) {
+					const MAX_RATE_LIMIT_RETRIES = 5
+					const retryAttempt = job.data.rate_limit_retry_attempt ?? 0
+
+					if (retryAttempt < MAX_RATE_LIMIT_RETRIES) {
+						job.log(`Rate limited (${error.retryAfterMs}ms). Retry ${retryAttempt + 1}/${MAX_RATE_LIMIT_RETRIES}`)
+						await job.updateData({
+							...job.data,
+							rate_limit_retry_attempt: retryAttempt + 1,
+						})
+						await job.moveToDelayed(Date.now() + error.retryAfterMs, token)
+						throw new DelayedError()
+					}
+
+					job.log(`Rate limited but exhausted ${MAX_RATE_LIMIT_RETRIES} retries, failing`)
+				}
+
+				throw error
 			}
 		}
 	},

--- a/server/workers/chapter-data.ts
+++ b/server/workers/chapter-data.ts
@@ -217,6 +217,7 @@ export default defineWorker<typeof QUEUE_NAME, ChapterDataJobData, undefined>({
 		metrics: { maxDataPoints: MetricsTime.ONE_WEEK * 2 },
 	},
 	async processor(job, token) {
+		const rateLimitMaxRetries = Number(useRuntimeConfig().rateLimitMaxRetries) || 5
 		const data = chapterDataJobDataSchema.parse(job.data)
 
 		await job.updateProgress(5)
@@ -258,11 +259,10 @@ export default defineWorker<typeof QUEUE_NAME, ChapterDataJobData, undefined>({
 			}
 			catch (error) {
 				if (error instanceof RateLimitError) {
-					const MAX_RATE_LIMIT_RETRIES = 5
 					const retryAttempt = job.data.rate_limit_retry_attempt ?? 0
 
-					if (retryAttempt < MAX_RATE_LIMIT_RETRIES) {
-						job.log(`Rate limited (${error.retryAfterMs}ms). Retry ${retryAttempt + 1}/${MAX_RATE_LIMIT_RETRIES}`)
+					if (retryAttempt < rateLimitMaxRetries) {
+						job.log(`Rate limited (${error.retryAfterMs}ms). Retry ${retryAttempt + 1}/${rateLimitMaxRetries}`)
 						await job.updateData({
 							...job.data,
 							rate_limit_retry_attempt: retryAttempt + 1,
@@ -271,7 +271,7 @@ export default defineWorker<typeof QUEUE_NAME, ChapterDataJobData, undefined>({
 						throw new DelayedError()
 					}
 
-					job.log(`Rate limited but exhausted ${MAX_RATE_LIMIT_RETRIES} retries, failing`)
+					job.log(`Rate limited but exhausted ${rateLimitMaxRetries} retries, failing`)
 				}
 
 				throw error

--- a/server/workers/serie-inserter.ts
+++ b/server/workers/serie-inserter.ts
@@ -22,6 +22,7 @@ export default defineWorker<typeof QUEUE_NAME, SerieInserterJobData, SerieInsert
 	},
 	async processor(job, token) {
 		const log = (msg: string) => job.log(`[Attempt ${job.attemptsMade + 1}] ${msg}`)
+		const rateLimitMaxRetries = Number(useRuntimeConfig().rateLimitMaxRetries) || 5
 		const {
 			source_id: sourceId,
 			source_serie_id: sourceSerieId,
@@ -477,11 +478,10 @@ export default defineWorker<typeof QUEUE_NAME, SerieInserterJobData, SerieInsert
 
 			// Handle 429 rate limits — delay the job without counting as a failure attempt
 			if (error instanceof RateLimitError) {
-				const MAX_RATE_LIMIT_RETRIES = 5
 				const retryAttempt = job.data.rate_limit_retry_attempt ?? 0
 
-				if (retryAttempt < MAX_RATE_LIMIT_RETRIES) {
-					log(`Rate limited (${error.retryAfterMs}ms). Retry ${retryAttempt + 1}/${MAX_RATE_LIMIT_RETRIES}`)
+				if (retryAttempt < rateLimitMaxRetries) {
+					log(`Rate limited (${error.retryAfterMs}ms). Retry ${retryAttempt + 1}/${rateLimitMaxRetries}`)
 					await job.updateData({
 						...job.data,
 						rate_limit_retry_attempt: retryAttempt + 1,
@@ -490,7 +490,7 @@ export default defineWorker<typeof QUEUE_NAME, SerieInserterJobData, SerieInsert
 					throw new DelayedError()
 				}
 
-				log(`Rate limited but exhausted ${MAX_RATE_LIMIT_RETRIES} retries, failing`)
+				log(`Rate limited but exhausted ${rateLimitMaxRetries} retries, failing`)
 			}
 
 			// Increment consecutive_failures on error

--- a/server/workers/serie-inserter.ts
+++ b/server/workers/serie-inserter.ts
@@ -11,6 +11,7 @@ import { db } from "../utils/db"
 import { getFlowProducer } from "../utils/flow-producer"
 import { resolveMultiLanguage, resolveSerieTitle } from "../utils/serie"
 import { getSourceById } from "../utils/sources"
+import { RateLimitError } from "../utils/sources/core"
 
 export default defineWorker<typeof QUEUE_NAME, SerieInserterJobData, SerieInserterJobResult>({
 	name: QUEUE_NAME,
@@ -472,6 +473,24 @@ export default defineWorker<typeof QUEUE_NAME, SerieInserterJobData, SerieInsert
 			// Re-throw DelayedError without treating it as a failure
 			if (error instanceof DelayedError) {
 				throw error
+			}
+
+			// Handle 429 rate limits — delay the job without counting as a failure attempt
+			if (error instanceof RateLimitError) {
+				const MAX_RATE_LIMIT_RETRIES = 5
+				const retryAttempt = job.data.rate_limit_retry_attempt ?? 0
+
+				if (retryAttempt < MAX_RATE_LIMIT_RETRIES) {
+					log(`Rate limited (${error.retryAfterMs}ms). Retry ${retryAttempt + 1}/${MAX_RATE_LIMIT_RETRIES}`)
+					await job.updateData({
+						...job.data,
+						rate_limit_retry_attempt: retryAttempt + 1,
+					})
+					await job.moveToDelayed(Date.now() + error.retryAfterMs, token)
+					throw new DelayedError()
+				}
+
+				log(`Rate limited but exhausted ${MAX_RATE_LIMIT_RETRIES} retries, failing`)
 			}
 
 			// Increment consecutive_failures on error


### PR DESCRIPTION
Detect 429 responses at the HTTP layer (MangaDex, WeebCentral, Byparr) and use BullMQ's moveToDelayed() to reschedule jobs after the rate limit window instead of burning through retry attempts.

- Add RateLimitError, parseRetryAfter(), assertNotRateLimited() to core
- Add #fetch() wrapper in MangaDex/WeebCentral scrapers
- Check solution.status in Byparr get/post methods
- Handle RateLimitError in serie-inserter and chapter-data workers with up to 5 rate-limit delays before falling through to normal failure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Centralized rate-limit handling across all content scrapers.
  * Automatic retry mechanism for rate-limited requests (up to 5 attempts) with server-provided delays.

* **Bug Fixes**
  * Improved parsing of Retry-After headers for better rate-limit compliance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->