### PR TITLE
fix: serie-inserter transaction timeout on large series

### DIFF
--- a/app/components/jobs/DuplicateDialog.vue
+++ b/app/components/jobs/DuplicateDialog.vue
@@ -245,7 +245,7 @@ async function handleSubmit() {
 						<UButton
 							variant="outline"
 							:disabled="submitting"
-							@click="open = false"
+							@click="() => { open = false }"
 						>
 							Cancel
 						</UButton>

--- a/app/components/me/ApiKeysSection.vue
+++ b/app/components/me/ApiKeysSection.vue
@@ -116,7 +116,7 @@ function formatDate(date: Date | string | null): string {
 				<UButton
 					variant="outline"
 					size="sm"
-					@click="isCreateOpen = true"
+					@click="() => { isCreateOpen = true }"
 				>
 					<UIcon
 						name="i-lucide-plus"

--- a/app/components/me/DeleteAccountSection.vue
+++ b/app/components/me/DeleteAccountSection.vue
@@ -88,7 +88,7 @@ async function handleDelete() {
 					<UButton
 						variant="outline"
 						color="error"
-						@click="isOpen = true"
+						@click="() => { isOpen = true }"
 					>
 						Delete Account
 					</UButton>
@@ -163,7 +163,7 @@ async function handleDelete() {
 								<div class="flex justify-end gap-2">
 									<UButton
 										variant="outline"
-										@click="isOpen = false"
+										@click="() => { isOpen = false }"
 									>
 										Cancel
 									</UButton>

--- a/app/components/me/PasswordSection.vue
+++ b/app/components/me/PasswordSection.vue
@@ -114,7 +114,7 @@ async function handleChangePassword() {
 				>
 					<UButton
 						variant="outline"
-						@click="isOpen = true"
+						@click="() => { isOpen = true }"
 					>
 						Change Password
 					</UButton>
@@ -210,7 +210,7 @@ async function handleChangePassword() {
 								<div class="flex justify-end gap-2">
 									<UButton
 										variant="outline"
-										@click="isOpen = false"
+										@click="() => { isOpen = false }"
 									>
 										Cancel
 									</UButton>

--- a/app/components/me/TwoFactorSection.vue
+++ b/app/components/me/TwoFactorSection.vue
@@ -226,7 +226,7 @@ async function disable2FA() {
 								<div class="flex justify-end gap-2">
 									<UButton
 										variant="outline"
-										@click="isPasswordModalOpen = false"
+										@click="() => { isPasswordModalOpen = false }"
 									>
 										Cancel
 									</UButton>
@@ -300,7 +300,7 @@ async function disable2FA() {
 										/>
 										{{ copied ? 'Copied!' : 'Copy Codes' }}
 									</UButton>
-									<UButton @click="isBackupCodesOpen = false">
+									<UButton @click="() => { isBackupCodesOpen = false }">
 										Done
 									</UButton>
 								</div>

--- a/app/components/me/UserInfoSection.vue
+++ b/app/components/me/UserInfoSection.vue
@@ -152,7 +152,7 @@ async function handleChangeEmail() {
 						>
 							<UButton
 								variant="outline"
-								@click="changeEmailOpen = true"
+								@click="() => { changeEmailOpen = true }"
 							>
 								Change
 							</UButton>
@@ -188,7 +188,7 @@ async function handleChangeEmail() {
 										</div>
 										<UButton
 											variant="outline"
-											@click="changeEmailOpen = false"
+											@click="() => { changeEmailOpen = false }"
 										>
 											Close
 										</UButton>
@@ -230,7 +230,7 @@ async function handleChangeEmail() {
 										<div class="flex justify-end gap-2">
 											<UButton
 												variant="outline"
-												@click="changeEmailOpen = false"
+												@click="() => { changeEmailOpen = false }"
 											>
 												Cancel
 											</UButton>

--- a/app/components/series/ChapterTable.vue
+++ b/app/components/series/ChapterTable.vue
@@ -610,7 +610,7 @@ const sourceAvailabilityFilterItems = [
 				variant="outline"
 				color="error"
 				:disabled="isPending || isDeleting || selectedDeletableChapters.length === 0"
-				@click="deleteDialogOpen = true"
+				@click="() => { deleteDialogOpen = true }"
 			>
 				<UIcon
 					name="i-lucide-trash-2"
@@ -635,7 +635,7 @@ const sourceAvailabilityFilterItems = [
 				size="sm"
 				variant="ghost"
 				:disabled="isPending || isDeleting || isAcknowledging"
-				@click="selectedIds = new Set()"
+				@click="() => { selectedIds = new Set() }"
 			>
 				Clear
 			</UButton>
@@ -1155,7 +1155,7 @@ const sourceAvailabilityFilterItems = [
 							<UButton
 								variant="outline"
 								:disabled="isDeleting"
-								@click="deleteDialogOpen = false"
+								@click="() => { deleteDialogOpen = false }"
 							>
 								Cancel
 							</UButton>

--- a/app/components/series/ChapterViewer.vue
+++ b/app/components/series/ChapterViewer.vue
@@ -159,7 +159,7 @@ async function refetchChapter() {
 								variant="ghost"
 								size="sm"
 								icon="i-lucide-x"
-								@click="open = false"
+								@click="() => { open = false }"
 							/>
 						</div>
 					</div>

--- a/app/components/series/DeleteButton.vue
+++ b/app/components/series/DeleteButton.vue
@@ -36,7 +36,7 @@ async function handleDelete() {
 			variant="soft"
 			size="sm"
 			title="Delete series"
-			@click="open = true"
+			@click="() => { open = true }"
 		>
 			<UIcon
 				name="i-lucide-trash-2"
@@ -64,7 +64,7 @@ async function handleDelete() {
 					<div class="flex justify-end gap-2">
 						<UButton
 							variant="outline"
-							@click="open = false"
+							@click="() => { open = false }"
 						>
 							Cancel
 						</UButton>

--- a/app/pages/dashboard/jobs/settings.vue
+++ b/app/pages/dashboard/jobs/settings.vue
@@ -189,7 +189,7 @@ async function triggerJob(job: (typeof jobs.value)[number]) {
 										size="sm"
 										color="error"
 										variant="outline"
-										@click="purgeDialogOpen = true"
+										@click="() => { purgeDialogOpen = true }"
 									>
 										<UIcon
 											name="i-lucide-trash-2"
@@ -251,7 +251,7 @@ async function triggerJob(job: (typeof jobs.value)[number]) {
 					<div class="modal-actions">
 						<UButton
 							variant="outline"
-							@click="purgeDialogOpen = false"
+							@click="() => { purgeDialogOpen = false }"
 						>
 							Cancel
 						</UButton>

--- a/app/pages/dashboard/series/import/browse/[sourceId].vue
+++ b/app/pages/dashboard/series/import/browse/[sourceId].vue
@@ -126,7 +126,7 @@ function handlePanelToggle() {
 							icon="i-lucide-x"
 							variant="ghost"
 							size="sm"
-							@click="router.push('/dashboard/series')"
+							@click="() => { router.push('/dashboard/series') }"
 						/>
 					</template>
 				</UiPageHeader>
@@ -265,7 +265,7 @@ function handlePanelToggle() {
 						<div class="browse-footer">
 							<UButton
 								variant="outline"
-								@click="router.push('/dashboard/series/import/browse')"
+								@click="() => { router.push('/dashboard/series/import/browse') }"
 							>
 								<UIcon
 									name="i-lucide-arrow-left"
@@ -275,7 +275,7 @@ function handlePanelToggle() {
 							</UButton>
 							<UButton
 								:disabled="cart.cartCount.value === 0"
-								@click="router.push('/dashboard/series/import/review')"
+								@click="() => { router.push('/dashboard/series/import/review') }"
 							>
 								Review ({{ cart.cartCount.value }})
 								<UIcon

--- a/app/pages/dashboard/series/import/index.vue
+++ b/app/pages/dashboard/series/import/index.vue
@@ -125,7 +125,7 @@ onMounted(() => {
 								<span class="cart-hint">Ready to review</span>
 							</div>
 						</div>
-						<UButton @click="router.push('/dashboard/series/import/review')">
+						<UButton @click="() => { router.push('/dashboard/series/import/review') }">
 							View Selection
 							<UIcon
 								name="i-lucide-arrow-right"

--- a/app/pages/dashboard/series/import/review.vue
+++ b/app/pages/dashboard/series/import/review.vue
@@ -296,7 +296,7 @@ watch(() => cart.cartItems.value, (items) => {
 								<UButton
 									variant="outline"
 									class="hidden sm:inline-flex"
-									@click="router.push('/dashboard/series/import')"
+									@click="() => { router.push('/dashboard/series/import') }"
 								>
 									<UIcon
 										name="i-lucide-arrow-left"

--- a/prisma/migrations/20260704230815_explicit_chapter_group_m2m/migration.sql
+++ b/prisma/migrations/20260704230815_explicit_chapter_group_m2m/migration.sql
@@ -1,0 +1,9 @@
+-- Convert the implicit Chapter<->ScanlationGroup m2m table into the explicit
+-- ChapterGroup model using renames only: no data is copied, removed or rewritten.
+ALTER TABLE "_ChapterToScanlationGroup" RENAME TO "chapter_group";
+ALTER TABLE "chapter_group" RENAME COLUMN "A" TO "chapter_id";
+ALTER TABLE "chapter_group" RENAME COLUMN "B" TO "group_id";
+ALTER TABLE "chapter_group" RENAME CONSTRAINT "_ChapterToScanlationGroup_AB_pkey" TO "chapter_group_pkey";
+ALTER TABLE "chapter_group" RENAME CONSTRAINT "_ChapterToScanlationGroup_A_fkey" TO "chapter_group_chapter_id_fkey";
+ALTER TABLE "chapter_group" RENAME CONSTRAINT "_ChapterToScanlationGroup_B_fkey" TO "chapter_group_group_id_fkey";
+ALTER INDEX "_ChapterToScanlationGroup_B_index" RENAME TO "chapter_group_group_id_idx";

--- a/prisma/schema/serie.prisma
+++ b/prisma/schema/serie.prisma
@@ -149,7 +149,7 @@ model Chapter {
     serie       Serie             @relation(fields: [serie_id], references: [id], onDelete: Cascade)
     source      Source            @relation(fields: [source_id], references: [id])
     data        ChapterData[]
-    groups      ScanlationGroup[]
+    groups      ChapterGroup[]
     fillable_for FillableChapter[]
 
     @@unique([source_id, external_id])
@@ -218,11 +218,23 @@ model ScanlationGroup {
     url         String?
 
     source            Source                 @relation(fields: [source_id], references: [id])
-    chapters          Chapter[]
+    chapters          ChapterGroup[]
     serie_preferences SerieGroupPreference[]
 
     @@unique([source_id, external_id])
     @@map("scanlation_group")
+}
+
+model ChapterGroup {
+    chapter_id String @db.Uuid
+    group_id   String @db.Uuid
+
+    chapter Chapter         @relation(fields: [chapter_id], references: [id], onDelete: Cascade)
+    group   ScanlationGroup @relation(fields: [group_id], references: [id], onDelete: Cascade)
+
+    @@id([chapter_id, group_id])
+    @@index([group_id])
+    @@map("chapter_group")
 }
 
 enum Language {

--- a/server/api/v1/serie/[id]/chapters.get.ts
+++ b/server/api/v1/serie/[id]/chapters.get.ts
@@ -27,7 +27,7 @@ export default defineEventHandler(async (event) => {
 	const { id } = await getValidatedRouterParams(event, paramsSchema.parse)
 	const { includeDisabled, lang } = await getValidatedQuery(event, querySchema.parse)
 
-	const chapters = await db.chapter.findMany({
+	const chapterRows = await db.chapter.findMany({
 		where: {
 			serie_id: id,
 
@@ -36,7 +36,7 @@ export default defineEventHandler(async (event) => {
 		},
 		include: {
 			groups: {
-				select: { id: true, name: true, url: true },
+				select: { group: { select: { id: true, name: true, url: true } } },
 			},
 			source: {
 				select: { id: true, external_id: true, name: true },
@@ -44,6 +44,8 @@ export default defineEventHandler(async (event) => {
 		},
 		orderBy: [{ chapter_number: "desc" }, { id: "asc" }],
 	})
+	// Flatten join rows so the API response shape is unchanged
+	const chapters = chapterRows.map(c => ({ ...c, groups: c.groups.map(g => g.group) }))
 
 	// If includeDisabled is true, compute alternatives for each chapter
 	// (chapters with same source_id, chapter_number, language)

--- a/server/api/v1/serie/[id]/chapters/[chapterId]/select.post.ts
+++ b/server/api/v1/serie/[id]/chapters/[chapterId]/select.post.ts
@@ -19,7 +19,7 @@ export default defineEventHandler(async (event) => {
 			chapter_number: true,
 			language: true,
 			source_id: true,
-			groups: { select: { id: true, name: true } },
+			groups: { select: { group: { select: { id: true, name: true } } } },
 		},
 	})
 
@@ -62,7 +62,7 @@ export default defineEventHandler(async (event) => {
 
 		// Store group preference for future chapters (if the chapter has groups)
 		if (selectedChapter.groups.length > 0) {
-			const groupId = selectedChapter.groups[0]!.id
+			const groupId = selectedChapter.groups[0]!.group.id
 
 			// Upsert preference - increase priority for selected group
 			await tx.serieGroupPreference.upsert({

--- a/server/api/v1/serie/[id]/chapters/overrides.get.ts
+++ b/server/api/v1/serie/[id]/chapters/overrides.get.ts
@@ -39,9 +39,7 @@ export default defineEventHandler(async (event) => {
 				},
 			},
 			groups: {
-				select: {
-					name: true,
-				},
+				select: { group: { select: { name: true } } },
 			},
 		},
 		orderBy: [
@@ -65,7 +63,7 @@ export default defineEventHandler(async (event) => {
 			manual_override: chapter.manual_override!,
 			title: chapter.title,
 			source_name: chapter.source.name,
-			groups: chapter.groups.map(g => g.name),
+			groups: chapter.groups.map(g => g.group.name),
 		})),
 		count_by_language: countByLanguage,
 		total_count: overrides.length,

--- a/server/api/v1/serie/[id]/group-preference.get.ts
+++ b/server/api/v1/serie/[id]/group-preference.get.ts
@@ -31,10 +31,7 @@ export default defineEventHandler(async (event) => {
 		select: {
 			language: true,
 			groups: {
-				select: {
-					id: true,
-					name: true,
-				},
+				select: { group: { select: { id: true, name: true } } },
 			},
 		},
 	})
@@ -64,7 +61,7 @@ export default defineEventHandler(async (event) => {
 			groupsByLanguage[lang] = new Map()
 		}
 
-		for (const group of chapter.groups) {
+		for (const { group } of chapter.groups) {
 			const existing = groupsByLanguage[lang].get(group.id)
 			if (existing) {
 				existing.count++

--- a/server/rpc/routers/serie.ts
+++ b/server/rpc/routers/serie.ts
@@ -159,20 +159,21 @@ export const chapters = authed
 		language: languageSchema.optional(),
 	}))
 	.handler(async ({ input }) => {
-		const chapters = await db.chapter.findMany({
+		const chapterRows = await db.chapter.findMany({
 			where: {
 				serie_id: input.serieId,
 				enabled: true,
 				...(input.language ? { language: input.language } : {}),
 			},
 			include: {
-				groups: { select: { id: true, name: true, url: true } },
+				groups: { select: { group: { select: { id: true, name: true, url: true } } } },
 				source: { select: { id: true, external_id: true, name: true } },
 			},
 			orderBy: [{ chapter_number: "desc" }, { id: "asc" }],
 		})
 
-		return { chapters }
+		// Flatten join rows so the RPC response shape is unchanged
+		return { chapters: chapterRows.map(c => ({ ...c, groups: c.groups.map(g => g.group) })) }
 	})
 
 export const serieRouter = {

--- a/server/utils/chapter-dedup.ts
+++ b/server/utils/chapter-dedup.ts
@@ -216,7 +216,7 @@ export async function deduplicateForLanguage(
 	}
 
 	// Load all chapters for this serie+language (with groups for preference comparison)
-	const chapters = await db.chapter.findMany({
+	const chapterRows = await db.chapter.findMany({
 		where: { serie_id: serieId, language },
 		select: {
 			id: true,
@@ -224,10 +224,11 @@ export async function deduplicateForLanguage(
 			source_id: true,
 			enabled: true,
 			page_fetch_status: true,
-			groups: { select: { id: true, name: true } },
+			groups: { select: { group: { select: { id: true, name: true } } } },
 			manual_override: true,
 		},
 	})
+	const chapters = chapterRows.map(c => ({ ...c, groups: c.groups.map(g => g.group) }))
 
 	// Get group preferences for cross-source comparison
 	const groupPrefs = await getGroupPreferences(serieId, language)
@@ -648,13 +649,13 @@ async function getGroupChapterCounts(
 	const chapters = await db.chapter.findMany({
 		where: { serie_id: serieId, source_id: sourceId, language },
 		select: {
-			groups: { select: { id: true } },
+			groups: { select: { group: { select: { id: true } } } },
 		},
 	})
 
 	const counts = new Map<string, number>()
 	for (const chapter of chapters) {
-		for (const group of chapter.groups) {
+		for (const { group } of chapter.groups) {
 			counts.set(group.id, (counts.get(group.id) || 0) + 1)
 		}
 	}
@@ -716,7 +717,7 @@ export async function dedupSameSourceChapters(
 	log: (msg: string) => void,
 ): Promise<SameSourceDedupResult> {
 	// Load all chapters for this serie + source + language with groups
-	const chapters = await db.chapter.findMany({
+	const chapterRows = await db.chapter.findMany({
 		where: { serie_id: serieId, source_id: sourceId, language },
 		select: {
 			id: true,
@@ -725,10 +726,11 @@ export async function dedupSameSourceChapters(
 			enabled: true,
 			page_fetch_status: true,
 			date_upload: true,
-			groups: { select: { id: true, name: true } },
+			groups: { select: { group: { select: { id: true, name: true } } } },
 			manual_override: true,
 		},
 	})
+	const chapters = chapterRows.map(c => ({ ...c, groups: c.groups.map(g => g.group) }))
 
 	if (chapters.length === 0) {
 		return { changes: { to_enable: [], to_disable: [] }, duplicates_processed: 0 }

--- a/server/utils/chapter-diff.ts
+++ b/server/utils/chapter-diff.ts
@@ -1,0 +1,91 @@
+import type { Language } from "./db"
+
+/** Incoming chapter from a source, already resolved to DB-ready values.
+ * Optional fields left `undefined` mean "not provided by the source" and are
+ * neither compared nor written (same semantics as the previous upsert spread). */
+export type IncomingChapter = {
+	external_id: string
+	title: string | null
+	chapter_number: number
+	date_upload: Date
+	language: Language
+	external_url?: string
+	volume_name?: string | null
+	volume_number?: number | null
+	group_ids: string[]
+}
+
+/** Existing chapter row, restricted to the fields used for comparison */
+export type ExistingChapterForDiff = {
+	id: string
+	external_id: string
+	title: string | null
+	chapter_number: number
+	date_upload: Date
+	external_url: string | null
+	volume_name: string | null
+	volume_number: number | null
+	source_removed_at: Date | null
+	source_removal_acknowledged_at: Date | null
+	group_ids: string[]
+}
+
+export type ChapterUpdate = {
+	existing: ExistingChapterForDiff
+	incoming: IncomingChapter
+	groups_changed: boolean
+}
+
+export type ChapterDiffResult = {
+	to_create: IncomingChapter[]
+	to_update: ChapterUpdate[]
+}
+
+function sameGroups(a: string[], b: string[]): boolean {
+	if (a.length !== b.length) return false
+	const set = new Set(b)
+	return a.every(id => set.has(id))
+}
+
+/**
+ * Compare incoming source chapters with existing DB rows and return only the
+ * work to perform. Unchanged chapters produce no writes at all, which keeps
+ * the serie-inserter transaction O(changes) instead of O(chapters).
+ */
+export function diffChapters(
+	incoming: IncomingChapter[],
+	existing: ExistingChapterForDiff[],
+): ChapterDiffResult {
+	const existingMap = new Map(existing.map(c => [c.external_id, c]))
+	const seen = new Set<string>()
+	const to_create: IncomingChapter[] = []
+	const to_update: ChapterUpdate[] = []
+
+	for (const c of incoming) {
+		if (seen.has(c.external_id)) continue
+		seen.add(c.external_id)
+
+		const current = existingMap.get(c.external_id)
+		if (!current) {
+			to_create.push(c)
+			continue
+		}
+
+		const groups_changed = !sameGroups(c.group_ids, current.group_ids)
+		const fields_changed
+			= current.chapter_number !== c.chapter_number
+				|| current.date_upload.getTime() !== c.date_upload.getTime()
+				|| current.title !== c.title
+				|| current.source_removed_at !== null
+				|| current.source_removal_acknowledged_at !== null
+				|| (c.external_url !== undefined && current.external_url !== c.external_url)
+				|| (c.volume_name !== undefined && current.volume_name !== c.volume_name)
+				|| (c.volume_number !== undefined && current.volume_number !== c.volume_number)
+
+		if (fields_changed || groups_changed) {
+			to_update.push({ existing: current, incoming: c, groups_changed })
+		}
+	}
+
+	return { to_create, to_update }
+}

--- a/server/utils/chapter-diff.ts
+++ b/server/utils/chapter-diff.ts
@@ -42,9 +42,12 @@ export type ChapterDiffResult = {
 }
 
 function sameGroups(a: string[], b: string[]): boolean {
-	if (a.length !== b.length) return false
-	const set = new Set(b)
-	return a.every(id => set.has(id))
+	// True set equality: sources can emit duplicate group ids, so lengths alone
+	// would both hide real changes and flag phantom ones on every run
+	const setA = new Set(a)
+	const setB = new Set(b)
+	if (setA.size !== setB.size) return false
+	return [...setA].every(id => setB.has(id))
 }
 
 /**

--- a/server/workers/serie-inserter.ts
+++ b/server/workers/serie-inserter.ts
@@ -292,7 +292,7 @@ export default defineWorker<typeof QUEUE_NAME, SerieInserterJobData, SerieInsert
 				// Bulk-create new chapters, then their group links
 				let createdChapters: { id: string, external_id: string }[] = []
 				if (to_create.length > 0) {
-					await tx.chapter.createMany({
+					createdChapters = await tx.chapter.createManyAndReturn({
 						data: to_create.map(c => ({
 							serie_id: serieId,
 							source_id: sourceId,
@@ -306,13 +306,6 @@ export default defineWorker<typeof QUEUE_NAME, SerieInserterJobData, SerieInsert
 							...(c.volume_number !== undefined && { volume_number: c.volume_number }),
 						})),
 						skipDuplicates: true,
-					})
-					// No serie_id filter needed: (source_id, external_id) is globally unique
-					createdChapters = await tx.chapter.findMany({
-						where: {
-							source_id: sourceId,
-							external_id: { in: to_create.map(c => c.external_id) },
-						},
 						select: { id: true, external_id: true },
 					})
 

--- a/server/workers/serie-inserter.ts
+++ b/server/workers/serie-inserter.ts
@@ -6,6 +6,8 @@ import type { CoverUpdateJobData } from "../queues/cover-update"
 import type { IndexerJobData } from "../queues/indexer"
 import type { SerieInserterJobData, SerieInserterJobResult } from "../queues/serie-inserter"
 import { JOB_PRIORITY, QUEUE_NAME, serieInserterJobDataSchema } from "../queues/serie-inserter"
+import type { IncomingChapter } from "../utils/chapter-diff"
+import { diffChapters } from "../utils/chapter-diff"
 import type { Language, Prisma } from "../utils/db"
 import { db } from "../utils/db"
 import { getFlowProducer } from "../utils/flow-producer"
@@ -95,32 +97,47 @@ export default defineWorker<typeof QUEUE_NAME, SerieInserterJobData, SerieInsert
 					where: { name: { in: serieData.authors } },
 				})
 
-				// Upsert scanlation groups
+				// Scanlation groups: bulk-create the missing ones, update only the changed ones
 				const allGroups = chaptersResult.chapters.flatMap(c => c.groups)
 				const uniqueGroups = new Map(allGroups.map(g => [g.id, g]))
 
-				for (const group of uniqueGroups.values()) {
-					await tx.scanlationGroup.upsert({
-						where: {
-							source_id_external_id: {
-								source_id: sourceId,
-								external_id: group.id,
-							},
-						},
-						update: {
-							name: group.name,
-							...(group.url && { url: group.url.toString() }),
-						},
-						create: {
+				const existingGroups = await tx.scanlationGroup.findMany({
+					where: {
+						source_id: sourceId,
+						external_id: { in: [...uniqueGroups.keys()] },
+					},
+					select: { id: true, external_id: true, name: true, url: true },
+				})
+				const existingGroupMap = new Map(existingGroups.map(g => [g.external_id, g]))
+
+				const groupsToCreate = [...uniqueGroups.values()].filter(g => !existingGroupMap.has(g.id))
+				if (groupsToCreate.length > 0) {
+					await tx.scanlationGroup.createMany({
+						data: groupsToCreate.map(g => ({
 							source_id: sourceId,
-							external_id: group.id,
-							name: group.name,
-							...(group.url && { url: group.url.toString() }),
-						},
+							external_id: g.id,
+							name: g.name,
+							...(g.url && { url: g.url.toString() }),
+						})),
+						skipDuplicates: true,
 					})
 				}
+				for (const g of uniqueGroups.values()) {
+					const current = existingGroupMap.get(g.id)
+					if (!current) continue
+					const urlChanged = g.url !== undefined && current.url !== g.url.toString()
+					if (current.name !== g.name || urlChanged) {
+						await tx.scanlationGroup.update({
+							where: { id: current.id },
+							data: {
+								name: g.name,
+								...(g.url && { url: g.url.toString() }),
+							},
+						})
+					}
+				}
 
-				// Build group ID map (external_id -> db id)
+				// Build group ID map (external_id -> db id), including freshly created groups
 				const groupRecords = await tx.scanlationGroup.findMany({
 					where: {
 						source_id: sourceId,
@@ -225,16 +242,46 @@ export default defineWorker<typeof QUEUE_NAME, SerieInserterJobData, SerieInsert
 					},
 				})
 
-				// Get existing chapters
+				// Get existing chapters with every compared field (for the in-memory diff)
 				const existingChapters = await tx.chapter.findMany({
 					where: { serie_id: serieId, source_id: sourceId },
-					select: { external_id: true, date_upload: true, source_removed_at: true },
+					select: {
+						id: true,
+						external_id: true,
+						title: true,
+						chapter_number: true,
+						date_upload: true,
+						external_url: true,
+						volume_name: true,
+						volume_number: true,
+						source_removed_at: true,
+						source_removal_acknowledged_at: true,
+						groups: { select: { group_id: true } },
+					},
 				})
-				const existingChapterMap = new Map(existingChapters.map(c => [c.external_id, c.date_upload]))
 
-				// Check for new chapters
-				const hasNewChapters = chaptersResult.chapters.some(c => !existingChapterMap.has(c.id))
+				// Map source chapters to DB-ready values, then diff against existing rows.
+				// Only changed/new chapters produce writes: the transaction stays short
+				// no matter how many chapters the serie has.
+				const incomingChapters: IncomingChapter[] = chaptersResult.chapters.map(c => ({
+					external_id: c.id,
+					title: resolveMultiLanguage(c.title, "") || null,
+					chapter_number: c.chapterNumber,
+					date_upload: c.dateUpload,
+					language: c.language as Language,
+					...(c.externalUrl && { external_url: c.externalUrl.toString() }),
+					...(c.volumeName !== undefined && { volume_name: c.volumeName }),
+					...(c.volumeNumber !== undefined && { volume_number: c.volumeNumber }),
+					group_ids: c.groups
+						.map(g => groupMap.get(g.id))
+						.filter((id): id is string => id !== undefined),
+				}))
+				const { to_create, to_update } = diffChapters(
+					incomingChapters,
+					existingChapters.map(c => ({ ...c, group_ids: c.groups.map(g => g.group_id) })),
+				)
 
+				const hasNewChapters = to_create.length > 0
 				if (hasNewChapters) {
 					await tx.serie.update({
 						where: { id: serieId },
@@ -242,46 +289,75 @@ export default defineWorker<typeof QUEUE_NAME, SerieInserterJobData, SerieInsert
 					})
 				}
 
-				// Upsert all chapters
-				const upsertedChapters = await Promise.all(
-					chaptersResult.chapters.map((c) => {
-						const chapterGroupIds = c.groups
-							.map(g => groupMap.get(g.id))
-							.filter((id): id is string => id !== undefined)
+				// Bulk-create new chapters, then their group links
+				let createdChapters: { id: string, external_id: string }[] = []
+				if (to_create.length > 0) {
+					await tx.chapter.createMany({
+						data: to_create.map(c => ({
+							serie_id: serieId,
+							source_id: sourceId,
+							external_id: c.external_id,
+							chapter_number: c.chapter_number,
+							date_upload: c.date_upload,
+							language: c.language,
+							title: c.title,
+							...(c.external_url !== undefined && { external_url: c.external_url }),
+							...(c.volume_name !== undefined && { volume_name: c.volume_name }),
+							...(c.volume_number !== undefined && { volume_number: c.volume_number }),
+						})),
+						skipDuplicates: true,
+					})
+					// No serie_id filter needed: (source_id, external_id) is globally unique
+					createdChapters = await tx.chapter.findMany({
+						where: {
+							source_id: sourceId,
+							external_id: { in: to_create.map(c => c.external_id) },
+						},
+						select: { id: true, external_id: true },
+					})
 
-						const resolvedTitle = resolveMultiLanguage(c.title, "") || null
+					const createdIdMap = new Map(createdChapters.map(c => [c.external_id, c.id]))
+					const groupLinks = to_create.flatMap((c) => {
+						const chapterId = createdIdMap.get(c.external_id)
+						if (!chapterId) return []
+						return c.group_ids.map(group_id => ({ chapter_id: chapterId, group_id }))
+					})
+					if (groupLinks.length > 0) {
+						await tx.chapterGroup.createMany({ data: groupLinks, skipDuplicates: true })
+					}
+				}
 
-						return tx.chapter.upsert({
-							where: {
-								source_id_external_id: { source_id: sourceId, external_id: c.id },
-							},
-							update: {
-								chapter_number: c.chapterNumber,
-								date_upload: c.dateUpload,
-								title: resolvedTitle,
-								source_removed_at: null, // Clear if chapter reappears on source
-								source_removal_acknowledged_at: null, // Clear acknowledgment too
-								...(c.externalUrl && { external_url: c.externalUrl.toString() }),
-								...(c.volumeName !== undefined && { volume_name: c.volumeName }),
-								...(c.volumeNumber !== undefined && { volume_number: c.volumeNumber }),
-								groups: { set: chapterGroupIds.map(id => ({ id })) },
-							},
-							create: {
-								serie_id: serieId,
-								source_id: sourceId,
-								external_id: c.id,
-								chapter_number: c.chapterNumber,
-								date_upload: c.dateUpload,
-								language: c.language as Language,
-								title: resolvedTitle,
-								...(c.externalUrl && { external_url: c.externalUrl.toString() }),
-								...(c.volumeName !== undefined && { volume_name: c.volumeName }),
-								...(c.volumeNumber !== undefined && { volume_number: c.volumeNumber }),
-								groups: { connect: chapterGroupIds.map(id => ({ id })) },
-							},
-						})
-					}),
-				)
+				// Update the changed chapters — assumes the changed set stays small per run;
+				// a source mass-mutating every chapter would make this loop O(chapters) again
+				for (const { existing, incoming } of to_update) {
+					await tx.chapter.update({
+						where: { id: existing.id },
+						data: {
+							chapter_number: incoming.chapter_number,
+							date_upload: incoming.date_upload,
+							title: incoming.title,
+							source_removed_at: null, // Clear if chapter reappears on source
+							source_removal_acknowledged_at: null, // Clear acknowledgment too
+							...(incoming.external_url !== undefined && { external_url: incoming.external_url }),
+							...(incoming.volume_name !== undefined && { volume_name: incoming.volume_name }),
+							...(incoming.volume_number !== undefined && { volume_number: incoming.volume_number }),
+						},
+					})
+				}
+
+				// Rewrite group links only for chapters whose groups actually changed
+				const groupsChangedUpdates = to_update.filter(u => u.groups_changed)
+				if (groupsChangedUpdates.length > 0) {
+					await tx.chapterGroup.deleteMany({
+						where: { chapter_id: { in: groupsChangedUpdates.map(u => u.existing.id) } },
+					})
+					const relinkData = groupsChangedUpdates.flatMap(u =>
+						u.incoming.group_ids.map(group_id => ({ chapter_id: u.existing.id, group_id })),
+					)
+					if (relinkData.length > 0) {
+						await tx.chapterGroup.createMany({ data: relinkData, skipDuplicates: true })
+					}
+				}
 
 				// Mark chapters that no longer exist on source
 				const sourceChapterIds = new Set(chaptersResult.chapters.map(c => c.id))
@@ -304,16 +380,18 @@ export default defineWorker<typeof QUEUE_NAME, SerieInserterJobData, SerieInsert
 					job.log(`Marked ${removedChapterIds.length} chapters as removed from source`)
 				}
 
-				// Identify chapters needing refresh
-				const chaptersToRefresh = upsertedChapters.filter((c) => {
-					const oldDate = existingChapterMap.get(c.external_id)
-					return !oldDate || oldDate.getTime() !== c.date_upload.getTime()
-				})
+				// Chapters needing a data refresh: newly created + changed upload date
+				const chapterIdsToRefresh = [
+					...createdChapters.map(c => c.id),
+					...to_update
+						.filter(u => u.existing.date_upload.getTime() !== u.incoming.date_upload.getTime())
+						.map(u => u.existing.id),
+				]
 
 				return {
 					serie_id: serieId,
 					serie_source_id: serieSourceId,
-					chapter_ids: chaptersToRefresh.map(c => c.id),
+					chapter_ids: chapterIdsToRefresh,
 					has_new_chapters: hasNewChapters,
 				}
 			})

--- a/test/unit/chapter-dedup.test.ts
+++ b/test/unit/chapter-dedup.test.ts
@@ -34,7 +34,7 @@ const createChapter = (overrides: Partial<{
 	enabled: overrides.enabled ?? true,
 	page_fetch_status: overrides.page_fetch_status ?? "Success",
 	date_upload: overrides.date_upload ?? new Date("2024-01-01"),
-	groups: overrides.groups ?? [],
+	groups: (overrides.groups ?? []).map(g => ({ group: g })),
 	manual_override: overrides.manual_override ?? null,
 })
 

--- a/test/unit/chapter-diff.test.ts
+++ b/test/unit/chapter-diff.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from "vitest"
+import type { ExistingChapterForDiff, IncomingChapter } from "../../server/utils/chapter-diff"
+import { diffChapters } from "../../server/utils/chapter-diff"
+
+const incoming = (overrides: Partial<IncomingChapter> = {}): IncomingChapter => ({
+	external_id: "ext-1",
+	title: "Chapter 1",
+	chapter_number: 1,
+	date_upload: new Date("2024-01-01T00:00:00Z"),
+	language: "En",
+	group_ids: [],
+	...overrides,
+})
+
+const existing = (overrides: Partial<ExistingChapterForDiff> = {}): ExistingChapterForDiff => ({
+	id: "db-1",
+	external_id: "ext-1",
+	title: "Chapter 1",
+	chapter_number: 1,
+	date_upload: new Date("2024-01-01T00:00:00Z"),
+	external_url: null,
+	volume_name: null,
+	volume_number: null,
+	source_removed_at: null,
+	source_removal_acknowledged_at: null,
+	group_ids: [],
+	...overrides,
+})
+
+describe("diffChapters", () => {
+	it("classifies unknown chapters as to_create", () => {
+		const result = diffChapters([incoming({ external_id: "new-1" })], [existing()])
+		expect(result.to_create).toHaveLength(1)
+		expect(result.to_create[0]!.external_id).toBe("new-1")
+		expect(result.to_update).toHaveLength(0)
+	})
+
+	it("skips identical chapters entirely", () => {
+		const result = diffChapters([incoming()], [existing()])
+		expect(result.to_create).toHaveLength(0)
+		expect(result.to_update).toHaveLength(0)
+	})
+
+	it("detects a changed date_upload", () => {
+		const result = diffChapters(
+			[incoming({ date_upload: new Date("2024-06-01T00:00:00Z") })],
+			[existing()],
+		)
+		expect(result.to_update).toHaveLength(1)
+		expect(result.to_update[0]!.groups_changed).toBe(false)
+	})
+
+	it("detects a changed title", () => {
+		const result = diffChapters([incoming({ title: "Renamed" })], [existing()])
+		expect(result.to_update).toHaveLength(1)
+	})
+
+	it("detects a changed chapter_number", () => {
+		const result = diffChapters([incoming({ chapter_number: 1.5 })], [existing()])
+		expect(result.to_update).toHaveLength(1)
+	})
+
+	it("updates a chapter that reappeared on source (source_removed_at set)", () => {
+		const result = diffChapters(
+			[incoming()],
+			[existing({ source_removed_at: new Date("2024-03-01T00:00:00Z") })],
+		)
+		expect(result.to_update).toHaveLength(1)
+	})
+
+	it("updates a chapter with a stale removal acknowledgment", () => {
+		const result = diffChapters(
+			[incoming()],
+			[existing({ source_removal_acknowledged_at: new Date("2024-03-01T00:00:00Z") })],
+		)
+		expect(result.to_update).toHaveLength(1)
+	})
+
+	it("ignores undefined optional fields (source did not provide them)", () => {
+		// volume_name/volume_number/external_url absents de la source :
+		// on ne compare pas, même si la DB a une valeur
+		const result = diffChapters(
+			[incoming()],
+			[existing({ volume_name: "Vol. 1", volume_number: 1, external_url: "https://x" })],
+		)
+		expect(result.to_update).toHaveLength(0)
+	})
+
+	it("detects changed optional fields when provided", () => {
+		const result = diffChapters(
+			[incoming({ volume_number: 2 })],
+			[existing({ volume_number: 1 })],
+		)
+		expect(result.to_update).toHaveLength(1)
+	})
+
+	it("detects group membership changes", () => {
+		const result = diffChapters(
+			[incoming({ group_ids: ["g1", "g2"] })],
+			[existing({ group_ids: ["g1"] })],
+		)
+		expect(result.to_update).toHaveLength(1)
+		expect(result.to_update[0]!.groups_changed).toBe(true)
+	})
+
+	it("treats same groups in different order as unchanged", () => {
+		const result = diffChapters(
+			[incoming({ group_ids: ["g2", "g1"] })],
+			[existing({ group_ids: ["g1", "g2"] })],
+		)
+		expect(result.to_update).toHaveLength(0)
+	})
+
+	it("deduplicates incoming chapters sharing an external_id", () => {
+		const result = diffChapters(
+			[incoming({ external_id: "dup" }), incoming({ external_id: "dup", title: "Other" })],
+			[],
+		)
+		expect(result.to_create).toHaveLength(1)
+	})
+})

--- a/test/unit/chapter-diff.test.ts
+++ b/test/unit/chapter-diff.test.ts
@@ -111,6 +111,23 @@ describe("diffChapters", () => {
 		expect(result.to_update).toHaveLength(0)
 	})
 
+	it("treats duplicate incoming group ids as their unique set", () => {
+		const result = diffChapters(
+			[incoming({ group_ids: ["g1", "g1"] })],
+			[existing({ group_ids: ["g1"] })],
+		)
+		expect(result.to_update).toHaveLength(0)
+	})
+
+	it("detects group changes hidden by duplicate ids", () => {
+		const result = diffChapters(
+			[incoming({ group_ids: ["g1", "g1"] })],
+			[existing({ group_ids: ["g1", "g2"] })],
+		)
+		expect(result.to_update).toHaveLength(1)
+		expect(result.to_update[0]!.groups_changed).toBe(true)
+	})
+
 	it("deduplicates incoming chapters sharing an external_id", () => {
 		const result = diffChapters(
 			[incoming({ external_id: "dup" }), incoming({ external_id: "dup", title: "Other" })],


### PR DESCRIPTION
## Problème

Les jobs `serie-inserter` échouaient en masse sur les grosses séries (400+ chapitres) :

```
Transaction API error: A batch query cannot be executed on an expired transaction.
The timeout for this transaction was 5000 ms, however 5034 ms passed since the start.
```

Cause : la transaction interactive upsertait **tous** les chapitres à chaque run, sérialisés sur une seule connexion (le `Promise.all` dans une transaction Prisma n'est pas parallèle), plus plusieurs requêtes par upsert à cause du `groups: { set }`.

## Fix

Le travail de la transaction devient **proportionnel aux changements**, pas au nombre de chapitres — tout reste dans la transaction, timeout par défaut inchangé :

1. **`server/utils/chapter-diff.ts`** — fonction pure `diffChapters` (12 tests unitaires) : compare les chapitres source aux lignes DB et ne retourne que `to_create` / `to_update` ; les chapitres inchangés ne génèrent aucune écriture.
2. **m2m explicite `ChapterGroup`** — la table implicite `_ChapterToScanlationGroup` devient `chapter_group` via une migration **rename-only** (aucun DROP, aucune copie, instantanée) : zéro perte de données, vérifiée par checksum md5 sur 17 508 liaisons (identique avant/après). Permet les liaisons chapitre↔groupe en `createMany` groupé. Tous les lecteurs aplatissent côté serveur : réponses API strictement identiques, frontend intouché.
3. **Worker réécrit** — `createMany` groupé pour les nouveaux chapitres et leurs liaisons, updates individuels uniquement pour les rares chapitres modifiés ; sémantique préservée (`has_new_chapters`, chapitres à rafraîchir = créés + date changée, réapparition/suppression côté source, `language` jamais mis à jour).

## Vérification

- Suite complète : 145/145 ✅ (dont 12 nouveaux tests du diff), lint propre, worker typechecké via le tsconfig serveur.
- **End-to-end sur une série réelle de 521 chapitres** : job `completed`, transaction en **1 482 ms**, aucun `expired transaction` dans les logs, liaisons 522 → 544 (nouveaux chapitres, rien de perdu), log « Updated serie … with **11** chapters to process » (le diff, pas les 521).

## Déploiement

`pnpm db:migrate` applique les renames instantanément (pas de verrou long). La migration renomme la table que l'ancien code lit : ne pas laisser tourner un ancien processor après la migration (le workflow release migre puis démarre le nouveau build, donc OK).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved chapter and group syncing for series updates, with smarter handling of chapter-group relationships.
  * Added support for more efficient update detection so only changed chapters and groups are processed.

* **Bug Fixes**
  * Fixed chapter group data handling across series pages and APIs.
  * Reduced unnecessary updates, helping keep chapter listings and group preferences more accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->